### PR TITLE
chore: fix duplicate API doc anchors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,22 +1,12 @@
 # API Reference
 
-## PCCBuilder
-
 ::: FECalc.PCCBuilder
-
-## TargetMOL
 
 ::: FECalc.TargetMOL
 
-## FECalc
-
 ::: FECalc.FECalc
 
-## postprocess
-
 ::: FECalc.postprocess
-
-## utils
 
 ::: FECalc.utils
 


### PR DESCRIPTION
## Summary
- remove redundant headings from API docs to avoid duplicate anchor IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9ed3da64c83309e33dcb8b53e5790