### PR TITLE
refactor: hide utility helpers from docs

### DIFF
--- a/FECalc/utils.py
+++ b/FECalc/utils.py
@@ -7,7 +7,8 @@ from subprocess import CalledProcessError
 import numpy as np
 
 
-def set_hw_env(
+# Prefix with underscore to mark as private and avoid mkdocs exposure
+def _set_hw_env(
     scheduler: str, nodes: int, cores: int, threads: int
 ) -> tuple[int, int, int]:
     """Resolve hardware settings for various job schedulers.
@@ -280,7 +281,8 @@ class cd:
         os.chdir(self.savedPath)
 
 
-def run_gmx(cmd, **kwargs):
+# Prefix with underscore to mark as private and avoid mkdocs exposure
+def _run_gmx(cmd, **kwargs):
     """Run a ``gmx`` command with improved error reporting.
 
     Parameters
@@ -324,7 +326,8 @@ def run_gmx(cmd, **kwargs):
         raise RuntimeError(msg) from e
 
 
-def extract_timestep(mdp_file: Path) -> str:
+# Prefix with underscore to mark as private and avoid mkdocs exposure
+def _extract_timestep(mdp_file: Path) -> str:
     """Return the ``dt`` value from a GROMACS ``.mdp`` file.
 
     Parameters

--- a/example/pcc_submit_example.py
+++ b/example/pcc_submit_example.py
@@ -6,7 +6,7 @@ from FECalc.TargetMOL import TargetMOL
 from FECalc.PCCBuilder import PCCBuilder
 from FECalc.FECalc import FECalc
 from FECalc.postprocess import postprocess
-from FECalc.utils import set_hw_env
+from FECalc.utils import _set_hw_env
 
 
 with open("system_settings.JSON") as f:
@@ -17,7 +17,7 @@ scheduler = settings.get("scheduler", "local")
 nodes = int(settings.get("nodes", 1))
 cores = int(settings.get("cores", 1))
 threads = int(settings.get("threads", 1))
-nodes, cores, threads = set_hw_env(scheduler, nodes, cores, threads)
+nodes, cores, threads = _set_hw_env(scheduler, nodes, cores, threads)
 
 PCC_output = Path(settings["PCC_output_dir"])
 PCC_settings = Path(settings["PCC_settings_json"])

--- a/tests/test_fe_additional.py
+++ b/tests/test_fe_additional.py
@@ -9,7 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import FECalc.FECalc as fe_mod
 
 from FECalc.FECalc import FECalc
-from FECalc.utils import extract_timestep
+from FECalc.utils import _extract_timestep
 
 
 def test_update_mdp_sets_temperature_and_steps(tmp_path):
@@ -20,7 +20,7 @@ def test_update_mdp_sets_temperature_and_steps(tmp_path):
     fe = FECalc.__new__(FECalc)
     fe.T = 310
 
-    fe.update_mdp(template, out, n_steps=1000)
+    fe._update_mdp(template, out, n_steps=1000)
     lines = out.read_text().splitlines()
 
     assert any("ref_t" in line and str(fe.T) in line for line in lines)
@@ -36,14 +36,14 @@ def test_update_mdp_retains_steps_when_not_provided(tmp_path):
     fe = FECalc.__new__(FECalc)
     fe.T = 300
 
-    fe.update_mdp(template, out)
+    fe._update_mdp(template, out)
     assert "nsteps = 500" in out.read_text()
 
 
 def test_extract_timestep_reads_dt(tmp_path):
     mdp = tmp_path / "md.mdp"
     mdp.write_text("dt = 0.002\n")
-    assert extract_timestep(mdp) == "0.002"
+    assert _extract_timestep(mdp) == "0.002"
 
 
 def test_is_continuous_identifies_gaps():
@@ -189,7 +189,7 @@ def test_eq_complex_propagates_missing_em_gro(tmp_path, monkeypatch):
     fe.box_size = 1
     fe._check_done = lambda stage: False
     fe._set_done = lambda stage: None
-    fe.update_mdp = lambda *args, **kwargs: None
+    fe._update_mdp = lambda *args, **kwargs: None
 
     monkeypatch.setattr(fe_mod, "subprocess", SimpleNamespace(run=_fake_run))
 
@@ -211,7 +211,7 @@ def test_pbmetad_raises_when_md_gro_missing(tmp_path, monkeypatch):
     fe.T = 300
     fe.metad_height = 1
     fe._create_plumed = lambda *args, **kwargs: None
-    fe.update_mdp = lambda *args, **kwargs: None
+    fe._update_mdp = lambda *args, **kwargs: None
     fe._set_done = lambda stage: None
 
     monkeypatch.setattr(fe_mod, "subprocess", SimpleNamespace(run=_fake_run))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 # ensure package root on path for import
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from FECalc.utils import _read_pdb, _write_coords_to_pdb, _prep_pdb, cd, set_hw_env, _place_in_box
+from FECalc.utils import _read_pdb, _write_coords_to_pdb, _prep_pdb, cd, _set_hw_env, _place_in_box
 
 
 def test_set_hw_env_slurm(monkeypatch):
@@ -15,13 +15,13 @@ def test_set_hw_env_slurm(monkeypatch):
     monkeypatch.setenv("SLURM_NTASKS_PER_NODE", "4")
     monkeypatch.setenv("SLURM_CPUS_PER_TASK", "8")
 
-    nodes, cores, threads = set_hw_env("slurm", nodes=1, cores=1, threads=1)
+    nodes, cores, threads = _set_hw_env("slurm", nodes=1, cores=1, threads=1)
 
     assert (nodes, cores, threads) == (2, 4, 8)
 
 
 def test_set_hw_env_local():
-    nodes, cores, threads = set_hw_env("local", nodes=1, cores=2, threads=3)
+    nodes, cores, threads = _set_hw_env("local", nodes=1, cores=2, threads=3)
     assert (nodes, cores, threads) == (1, 2, 3)
 
 


### PR DESCRIPTION
## Summary
- prefix common helper functions with underscores so MkDocs ignores them
- update FECalc to use private helpers like `_update_mdp`, `_run_gmx`, and `_extract_timestep`
- adjust examples and tests to the new private API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9f70fb33c833094aebd700224f63a